### PR TITLE
Adding command line argument parsing

### DIFF
--- a/rtris.py
+++ b/rtris.py
@@ -4,7 +4,7 @@ import os,random,math,json,subprocess
 from numpy import add as np_add
 os.environ['PYGAME_HIDE_SUPPORT_PROMPT'] = "hide"
 import pygame,pygame.freetype
-from sys import argv
+from sys import argv,stderr
 
 K_DROP=False
 confpath=os.path.abspath(os.path.expanduser("~/.rtrisconf"))
@@ -41,7 +41,6 @@ There is NO WARRANTY, to the extent permitted by law.
 Written by %s.""" % (VERSION, COPYRIGHT_YEAR, COPYRIGHT_HOLDER, AUTHORS)
 
 def eprint(*args, **kwargs):
-	from sys import stderr
 	print(*args, file=stderr, **kwargs)
 
 def opt_help(opt, arg):

--- a/rtris.py
+++ b/rtris.py
@@ -58,7 +58,6 @@ def opt_version_info(opt, arg):
 
 debug=False
 def dprint(*args, **kwargs):
-	global debug
 	if debug:
 		print(*args, **kwargs)
 def opt_debug(opt, arg):

--- a/rtris.py
+++ b/rtris.py
@@ -23,7 +23,6 @@ HELP="""\
       -h, --help      display this summary and exit
       -V, --version   display version information and exit
       -d, --debug     print debug information
-      -D, --no-debug  don't print debug information (default)
 
     Exit Status:
       (using CommonCodes v1.0.0
@@ -66,12 +65,6 @@ def opt_debug(opt, arg):
 		eprint("%s: %s: too many arguments: 1" % (argv[0], opt))
 		exit(4)
 	debug=True
-def opt_no_debug(opt, arg):
-	global debug
-	if arg != None:
-		eprint("%s: %s: too many arguments: 1" % (argv[0], opt))
-		exit(4)
-	debug=False
 
 # options are stored in this array here as tuples
 # tuple[0]: array of single character strings representing the short options
@@ -92,8 +85,7 @@ def opt_no_debug(opt, arg):
 options=[
 	(["h"], ["help"],     False, opt_help,         True),
 	(["V"], ["version"],  False, opt_version_info, True),
-	(["d"], ["debug"],    False, opt_debug,        False),
-	(["D"], ["no-debug"], False, opt_no_debug,     False)
+	(["d"], ["debug"],    False, opt_debug,        False)
 ]
 
 if __name__=="__main__":

--- a/rtris.py
+++ b/rtris.py
@@ -149,6 +149,9 @@ if __name__=="__main__":
 		else:
 			eprint("%s: %s: invalid option" % (argv[0], opt[1]))
 			exit(5)
+	if len(args) > 0:
+		eprint("%s: too many arguments: %d" % (argv[0], len(args)))
+		exit(4)
 	if not os.path.exists(confpath):
 		strg={"left":pygame.K_LEFT,
 			"right":pygame.K_RIGHT,

--- a/rtris.py
+++ b/rtris.py
@@ -101,7 +101,6 @@ options=[
 
 if __name__=="__main__":
 	from re import match
-	ignopt=False
 	args=[]
 	hpoptqueue=[] # high priority option queue
 	lpoptqueue=[] # low priority option queue

--- a/rtris.py
+++ b/rtris.py
@@ -22,8 +22,8 @@ HELP="""\
     Options:
       -h, --help      display this summary and exit
       -V, --version   display version information and exit
-      -d, --debug     print debug information (default)
-      -D, --no-debug  don't print debug information
+      -d, --debug     print debug information
+      -D, --no-debug  don't print debug information (default)
 
     Exit Status:
       (using CommonCodes v1.0.0
@@ -56,7 +56,7 @@ def opt_version_info(opt, arg):
 	print(VERSION_INFO)
 	exit(0)
 
-debug=True
+debug=False
 def dprint(*args, **kwargs):
 	global debug
 	if debug:

--- a/rtris.py
+++ b/rtris.py
@@ -9,9 +9,52 @@ from sys import argv
 K_DROP=False
 confpath=os.path.abspath(os.path.expanduser("~/.rtrisconf"))
 
+VERSION="1.0a3"
+COPYRIGHT_YEAR="2019"
+# TODO: do you wanna give out your full name?
+COPYRIGHT_HOLDER="RIEDLER"
+AUTHORS="RIEDLER and Michael Federczuk"
+
+USAGE="usage: %s" % (argv[0])
+HELP="""\
+%s
+    Start Rtris, a Tetris clone written in Python.
+
+    Options:
+      -h, --help     display this summary and exit
+      -V, --version  display version information and exit
+
+    Exit Status:
+      (using CommonCodes v1.0.0
+       <https://mfederczuk.github.io/commoncodes/v/1.0.0.html>)
+
+Report bugs at: https://github.com/RiedleroD/Rtris/issues
+Rtris repository: https://github.com/RiedleroD/Rtris""" % (USAGE)
+VERSION_INFO="""\
+Rtris %s
+Copyright (c) %s %s
+License CC BY-SA 4.0: Creative Commons Attribution-ShareAlike 4.0 <http://creativecommons.org/licenses/by-sa/4.0>
+This is free software: you are free to change and redistribute it.
+There is NO WARRANTY, to the extent permitted by law.
+
+Written by %s.""" % (VERSION, COPYRIGHT_YEAR, COPYRIGHT_HOLDER, AUTHORS)
+
 def eprint(*args, **kwargs):
 	from sys import stderr
 	print(*args, file=stderr, **kwargs)
+
+def opt_help(opt, arg):
+	if arg != None:
+		eprint("%s: %s: too many arguments: 1" % (argv[0], opt))
+		exit(4)
+	print(HELP)
+	exit(0)
+def opt_version_info(opt, arg):
+	if arg != None:
+		eprint("%s: %s: too many arguments: 1" % (argv[0], opt))
+		exit(4)
+	print(VERSION_INFO)
+	exit(0)
 
 # options are stored in this array here as tuples
 # tuple[0]: array of single character strings representing the short options
@@ -29,7 +72,10 @@ def eprint(*args, **kwargs):
 #            checking for invalid options and BEFORE the low priority options.
 #            if False, the option is low priority and will be executed AFTER
 #            checking for invalid options and AFTER the high priority options
-options=[]
+options=[
+	(["h"], ["help"],    False, opt_help,         True),
+	(["V"], ["version"], False, opt_version_info, True)
+]
 
 if __name__=="__main__":
 	from re import match

--- a/rtris.py
+++ b/rtris.py
@@ -62,16 +62,16 @@ def dprint(*args, **kwargs):
 	if debug:
 		print(*args, **kwargs)
 def opt_debug(opt, arg):
+	global debug
 	if arg != None:
 		eprint("%s: %s: too many arguments: 1" % (argv[0], opt))
 		exit(4)
-	global debug
 	debug=True
 def opt_no_debug(opt, arg):
+	global debug
 	if arg != None:
 		eprint("%s: %s: too many arguments: 1" % (argv[0], opt))
 		exit(4)
-	global debug
 	debug=False
 
 # options are stored in this array here as tuples

--- a/rtris.py
+++ b/rtris.py
@@ -21,8 +21,10 @@ HELP="""\
     Start Rtris, a Tetris clone written in Python.
 
     Options:
-      -h, --help     display this summary and exit
-      -V, --version  display version information and exit
+      -h, --help      display this summary and exit
+      -V, --version   display version information and exit
+      -d, --debug     print debug information (default)
+      -D, --no-debug  don't print debug information
 
     Exit Status:
       (using CommonCodes v1.0.0
@@ -56,6 +58,24 @@ def opt_version_info(opt, arg):
 	print(VERSION_INFO)
 	exit(0)
 
+debug=True
+def dprint(*args, **kwargs):
+	global debug
+	if debug:
+		print(*args, **kwargs)
+def opt_debug(opt, arg):
+	if arg != None:
+		eprint("%s: %s: too many arguments: 1" % (argv[0], opt))
+		exit(4)
+	global debug
+	debug=True
+def opt_no_debug(opt, arg):
+	if arg != None:
+		eprint("%s: %s: too many arguments: 1" % (argv[0], opt))
+		exit(4)
+	global debug
+	debug=False
+
 # options are stored in this array here as tuples
 # tuple[0]: array of single character strings representing the short options
 # tuple[1]: array of strings representing the long options
@@ -73,8 +93,10 @@ def opt_version_info(opt, arg):
 #            if False, the option is low priority and will be executed AFTER
 #            checking for invalid options and AFTER the high priority options
 options=[
-	(["h"], ["help"],    False, opt_help,         True),
-	(["V"], ["version"], False, opt_version_info, True)
+	(["h"], ["help"],     False, opt_help,         True),
+	(["V"], ["version"],  False, opt_version_info, True),
+	(["d"], ["debug"],    False, opt_debug,        False),
+	(["D"], ["no-debug"], False, opt_no_debug,     False)
 ]
 
 if __name__=="__main__":
@@ -183,26 +205,26 @@ except:
 		try:
 			w,h=subprocess.Popen(["xrandr | grep '*'"],shell=True,stdout=subprocess.PIPE).communicate()[0].split()[0].split(b"x")
 		except Exception as e:
-			print("Uhh... everything failed style")
+			dprint("Uhh... everything failed style")
 			_dispinfo=pygame.display.Info()	#When everythin fails, I.E. on not windows-, linux- or MacOS-based machines.
 			HEIGHT=_dispinfo.current_h
 			WIDTH=_dispinfo.current_w
 		else:
-			print("Unix style")
+			dprint("Unix style")
 			HEIGHT,WIDTH=int(h),int(w)
 	else:
-		print("MacOS style")
+		dprint("MacOS style")
 		macsize=NSScreen.screens()[0].frame().size	#this should work, according to https://stackoverflow.com/a/3129567/10499494, but I have noone to test it...
 		HEIGHT=macsize.height
 		WIDTH=macsize.width
 else:
-	print("Windows style")
+	dprint("Windows style")
 	user32=windll.user32	#yep, windows fully through
 	user32.SetProcessDPIAware()
 	HEIGHT=user32.GetSystemMetrics(78)
 	WIDTH=user32.GetSystemMetrics(79)
 
-print(WIDTH,HEIGHT)
+dprint(WIDTH,HEIGHT)
 
 BORDER_WIDTH=5
 BLACK=(0,0,0)

--- a/rtris.py
+++ b/rtris.py
@@ -4,7 +4,7 @@ import os,random,math,json,subprocess
 from numpy import add as np_add
 os.environ['PYGAME_HIDE_SUPPORT_PROMPT'] = "hide"
 import pygame,pygame.freetype
-from sys import argv,stderr
+from sys import argv
 
 K_DROP=False
 confpath=os.path.abspath(os.path.expanduser("~/.rtrisconf"))
@@ -24,10 +24,6 @@ HELP="""\
       -V, --version   display version information and exit
       -d, --debug     print debug information
 
-    Exit Status:
-      (using CommonCodes v1.0.0
-       <https://mfederczuk.github.io/commoncodes/v/1.0.0.html>)
-
 Report bugs at: https://github.com/RiedleroD/Rtris/issues
 Rtris repository: https://github.com/RiedleroD/Rtris""" % (USAGE)
 VERSION_INFO="""\
@@ -39,19 +35,14 @@ There is NO WARRANTY, to the extent permitted by law.
 
 Written by %s.""" % (VERSION, COPYRIGHT_YEAR, COPYRIGHT_HOLDER, AUTHORS)
 
-def eprint(*args, **kwargs):
-	print(*args, file=stderr, **kwargs)
-
 def opt_help(opt, arg):
 	if arg != None:
-		eprint("%s: %s: too many arguments: 1" % (argv[0], opt))
-		exit(4)
+		raise Exception("%s: too many arguments: 1" % (opt))
 	print(HELP)
 	exit(0)
 def opt_version_info(opt, arg):
 	if arg != None:
-		eprint("%s: %s: too many arguments: 1" % (argv[0], opt))
-		exit(4)
+		raise Exception("%s: too many arguments: 1" % (opt))
 	print(VERSION_INFO)
 	exit(0)
 
@@ -62,8 +53,7 @@ def dprint(*args, **kwargs):
 def opt_debug(opt, arg):
 	global debug
 	if arg != None:
-		eprint("%s: %s: too many arguments: 1" % (argv[0], opt))
-		exit(4)
+		raise Exception("%s: too many arguments: 1" % (opt))
 	debug=True
 
 # options are stored in this array here as tuples
@@ -157,11 +147,9 @@ if __name__=="__main__":
 		if opt[0] != None:
 			opt[0](opt[1], opt[2])
 		else:
-			eprint("%s: %s: invalid option" % (argv[0], opt[1]))
-			exit(5)
+			raise Exception("%s: invalid option" % (opt[1]))
 	if len(args) > 0:
-		eprint("%s: too many arguments: %d" % (argv[0], len(args)))
-		exit(4)
+		raise Exception("too many arguments: %d" % (len(args)))
 	if not os.path.exists(confpath):
 		strg={"left":pygame.K_LEFT,
 			"right":pygame.K_RIGHT,

--- a/rtris.py
+++ b/rtris.py
@@ -11,9 +11,8 @@ confpath=os.path.abspath(os.path.expanduser("~/.rtrisconf"))
 
 VERSION="1.0a3"
 COPYRIGHT_YEAR="2019"
-# TODO: do you wanna give out your full name?
-COPYRIGHT_HOLDER="RIEDLER"
-AUTHORS="RIEDLER and Michael Federczuk"
+COPYRIGHT_HOLDER="Riedler"
+AUTHORS="Rielder and Michael Federczuk"
 
 USAGE="usage: %s" % (argv[0])
 HELP="""\


### PR DESCRIPTION
Pretty good argument parser with long option (GNU style) and short option (POSIX style) support.  
Its really easy to add new options too, you just gotta add a new element to the `options` array.

I've added four options already: `--help`, `--version`, `--debug` and `--no-debug`.  
Make sure to always use `dprint` instead of `print` (if you actually merge this, lol) so that people can disable debug messages easily.

I got a question, though. The `--version` would list the copyright holder (you) and the authors (you and me). Would it be ok for you if we would write your full name on there?

(also I pushed two small commits to master make sure to pull before committing anything, lol)