### PR TITLE
Options with numerical priorities

### DIFF
--- a/rtris.py
+++ b/rtris.py
@@ -33,10 +33,15 @@ else:
 		conf=json.load(conffile)
 		strg=conf["strg"]
 try:
-	update=conf["update"]
+	tmp=conf["update"]
+	if tmp == True:
+		update=True # update
+	else:
+		update=None # don't update and don't print message saying to not update
+	# if update is set to False: don't update and print message to not update
 except KeyError:
 	conf["update"]=True
-	update=conf["update"]
+	update=conf["update"] # update
 debug=False
 
 COPYRIGHT_YEAR="2019"
@@ -128,11 +133,10 @@ def opt_version_info(opt, arg):
 	print(VERSION_INFO)
 	exit(0)
 def opt_update(opt, arg):
+	global update
 	if arg != None:
 		raise Exception("%s: too many arguments: 1" % (opt))
-	updater=Updater()
-	updater.update()
-	exit(0)
+	update=True
 
 def dprint(*args, **kwargs):
 	if debug:
@@ -147,7 +151,6 @@ def opt_no_update(opt, arg):
 	global update
 	if arg != None:
 		raise Exception("%s: too many arguments: 1" % (opt))
-	dprint("skipped updating")
 	update=False
 
 # options are stored in this array here as tuples
@@ -252,6 +255,13 @@ if __name__=="__main__":
 			raise Exception("%s: invalid option" % (opt[1]))
 	if len(args) > 0:
 		raise Exception("too many arguments: %d" % (len(args)))
+
+if update == True:
+	updater=Updater()
+	updater.update()
+	exit(0)
+elif update == False:
+	dprint("skipped updating")
 
 pygame.init()
 pygame.freetype.init()

--- a/rtris.py
+++ b/rtris.py
@@ -201,9 +201,9 @@ if __name__=="__main__":
 							optarg=argv[i + 1]
 							i+=1
 					if option[4]:
-						hpoptqueue.append((option[3], "--" + opt, optarg))
+						hpoptqueue.append((option, "--" + opt, optarg))
 					else:
-						lpoptqueue.append((option[3], "--" + opt, optarg))
+						lpoptqueue.append((option, "--" + opt, optarg))
 					break
 			if not option_found:
 				lpoptqueue.insert(0, (None, "--" + opt))
@@ -226,9 +226,9 @@ if __name__=="__main__":
 								optarg=argv[i + 1]
 								i+=1
 						if option[4]:
-							hpoptqueue.append((option[3], "-" + opt, optarg))
+							hpoptqueue.append((option, "-" + opt, optarg))
 						else:
-							lpoptqueue.append((option[3], "-" + opt, optarg))
+							lpoptqueue.append((option, "-" + opt, optarg))
 						break
 				if not option_found:
 					lpoptqueue.insert(0, (None, "-" + opt))
@@ -241,7 +241,7 @@ if __name__=="__main__":
 		i+=1
 	for opt in [*hpoptqueue, *lpoptqueue]:
 		if opt[0] != None:
-			opt[0](opt[1], opt[2])
+			opt[0][3](opt[1], opt[2])
 		else:
 			raise Exception("%s: invalid option" % (opt[1]))
 	if len(args) > 0:

--- a/rtris.py
+++ b/rtris.py
@@ -166,12 +166,16 @@ def opt_no_update(opt, arg):
 #            checking for invalid options and BEFORE the low priority options.
 #            if False, the option is low priority and will be executed AFTER
 #            checking for invalid options and AFTER the high priority options
+# tuple[5]: number specifying the exact priority. options with higher priority
+#            are executed before lower ones.
+#           position of passed down argument decides what option to execute
+#            first when priority is the same
 options=[
-	(["h"], ["help"],     False, opt_help,         True),
-	(["V"], ["version"],  False, opt_version_info, True),
-	(["d"], ["debug"],    False, opt_debug,        False),
-	(["U"], ["update"],   False, opt_update,       False),
-	(["u"], ["no-update"],False, opt_no_update,    False)
+	(["h"], ["help"],      False, opt_help,         True,  0),
+	(["V"], ["version"],   False, opt_version_info, True,  0),
+	(["d"], ["debug"],     False, opt_debug,        False, 1),
+	(["U"], ["update"],    False, opt_update,       False, 0),
+	(["u"], ["no-update"], False, opt_no_update,    False, 0)
 ]
 
 if __name__=="__main__":
@@ -239,6 +243,8 @@ if __name__=="__main__":
 			else:
 				args.append(arg)
 		i+=1
+	hpoptqueue.sort(key=lambda opt: opt[0][5], reverse=True)
+	lpoptqueue.sort(key=lambda opt: opt[0][5], reverse=True)
 	for opt in [*hpoptqueue, *lpoptqueue]:
 		if opt[0] != None:
 			opt[0][3](opt[1], opt[2])

--- a/rtris.py
+++ b/rtris.py
@@ -33,15 +33,10 @@ else:
 		conf=json.load(conffile)
 		strg=conf["strg"]
 try:
-	tmp=conf["update"]
-	if tmp == True:
-		update=True # update
-	else:
-		update=None # don't update and don't print message saying to not update
-	# if update is set to False: don't update and print message to not update
+	update=conf["update"]
 except KeyError:
 	conf["update"]=True
-	update=conf["update"] # update
+	update=conf["update"]
 debug=False
 
 COPYRIGHT_YEAR="2019"
@@ -133,10 +128,11 @@ def opt_version_info(opt, arg):
 	print(VERSION_INFO)
 	exit(0)
 def opt_update(opt, arg):
-	global update
 	if arg != None:
 		raise Exception("%s: too many arguments: 1" % (opt))
-	update=True
+	updater=Updater()
+	updater.update()
+	exit(0)
 
 def dprint(*args, **kwargs):
 	if debug:
@@ -151,6 +147,7 @@ def opt_no_update(opt, arg):
 	global update
 	if arg != None:
 		raise Exception("%s: too many arguments: 1" % (opt))
+	dprint("skipped updating")
 	update=False
 
 # options are stored in this array here as tuples
@@ -255,13 +252,6 @@ if __name__=="__main__":
 			raise Exception("%s: invalid option" % (opt[1]))
 	if len(args) > 0:
 		raise Exception("too many arguments: %d" % (len(args)))
-
-if update == True:
-	updater=Updater()
-	updater.update()
-	exit(0)
-elif update == False:
-	dprint("skipped updating")
 
 pygame.init()
 pygame.freetype.init()


### PR DESCRIPTION
Additional to being high and low priority, options can now have an exact numerical priority number.  
High priority are still being executed before low priority options and before checking for invalid options.

I had to change the way updates are checked for, since this wouldn't have made sense with the new option system.

This resolves issue #16.